### PR TITLE
Fix out of place outline when elements are clicked on mobile devices

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -64,3 +64,7 @@ body, html, input, button {
   -moz-osx-font-smoothing: grayscale;
   font-size: 1rem;
 }
+
+*:focus {
+  outline: none;
+}


### PR DESCRIPTION
This is a follow up to PR https://github.com/JamesHawkinss/movie-web/pull/51 which introduced keyboard navigation support. This PR fixes a minor bug that shows a blue outline on elements with `tabindex=0` on mobile.

It looks similar to the screenshot below.

<img width="409" alt="Screenshot 2022-01-08 at 21 16 51" src="https://user-images.githubusercontent.com/78268167/148660254-1cb3236f-5144-4f4d-aa00-f42ceaa04ca5.png">

The style change completely removes this outline, making the outlines behave exactly as they did before https://github.com/JamesHawkinss/movie-web/pull/51.