### PR TITLE
Fix TV if quality is lower than 1080p or 720p

### DIFF
--- a/src/providers/list/superstream/index.ts
+++ b/src/providers/list/superstream/index.ts
@@ -174,10 +174,12 @@ export const superStreamScraper: MWMediaProvider = {
       };
       const mediaRes = (await get(apiQuery).then((r) => r.json())).data;
       const hdQuality =
-        mediaRes.list.find((quality: any) => quality.quality === "1080p") ??
-        mediaRes.list.find((quality: any) => quality.quality === "720p") ??
-        mediaRes.list.find((quality: any) => quality.quality === "480p") ??
-        mediaRes.list.find((quality: any) => quality.quality === "360p");
+        mediaRes.list.find((quality: any) => (quality.quality === "1080p" && quality.path)) ??
+        mediaRes.list.find((quality: any) => (quality.quality === "720p" && quality.path)) ??
+        mediaRes.list.find((quality: any) => (quality.quality === "480p" && quality.path)) ??
+        mediaRes.list.find((quality: any) => (quality.quality === "360p" && quality.path));
+
+      if (!hdQuality) throw new Error("No quality could be found.");
 
       const subtitleApiQuery = {
         fid: hdQuality.fid,
@@ -215,8 +217,12 @@ export const superStreamScraper: MWMediaProvider = {
     };
     const mediaRes = (await get(apiQuery).then((r) => r.json())).data;
     const hdQuality =
-      mediaRes.list.find((quality: any) => quality.quality === "1080p") ??
-      mediaRes.list.find((quality: any) => quality.quality === "720p");
+      mediaRes.list.find((quality: any) => (quality.quality === "1080p" && quality.path)) ??
+      mediaRes.list.find((quality: any) => (quality.quality === "720p" && quality.path)) ??
+      mediaRes.list.find((quality: any) => (quality.quality === "480p" && quality.path)) ??
+      mediaRes.list.find((quality: any) => (quality.quality === "360p" && quality.path));
+
+    if (!hdQuality) throw new Error("No quality could be found.");
 
     const subtitleApiQuery = {
       fid: hdQuality.fid,


### PR DESCRIPTION
```diff
+ Check for 1080p, 720p, 480p, and 360p instead of 1080p & 720p only.
+ Throw an error if no quality could be found.
```